### PR TITLE
Fixed issues with PhoneGap 3.1.0 and XCode 5

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,7 @@
   </js-module>
   <asset src="www/litegap-example.html" target="litegap-example.html"/>
   <engines>
-    <engine name="cordova" version="3.0.0"/>
+    <engine name="cordova" version=">=3.0.0"/>
   </engines>
   <platform name="ios">
     <config-file target="config.xml" parent="/widget">
@@ -24,6 +24,7 @@
     <framework src="libicucore.dylib"/>
     <framework src="libz.dylib"/>
     <framework src="Security.framework"/>
+    <framework src="CFNetwork.framework"/>
     <header-file src="lib/ios/CBLRegisterJSViewCompiler.h"/>
     <source-file framework="true" src="lib/ios/CouchbaseLite.framework/CouchbaseLite.a"/>
     <header-file src="lib/ios/CouchbaseLite.framework/Headers/CBLAttachment.h"/>


### PR DESCRIPTION
I was running into the gray screen issue when following the instructions on the Getting Started page. It looks like this was because PhoneGap is currently at 3.1.0 and the plugin was looking for 3.0.0. This caused the plugin to get into a funky state where it was sort of installed, but didn't get included in Xcode. Since the plugin wasn't there, the JavaScript was stopping when it tried to load window.cblite which led to the gray screen.

In the middle of all this, I also had problems with the Xcode linker because CBL relies on some stuff in CFNetwork apparently. Adding this to the plugin.xml seemed to fix that issue.

Now I can follow the directions exactly (except for adding the local version of the plugin instead of the Github one) and it builds perfectly on Xcode 5.0.1 running in the iOS 6.1 and 7.0 emulators.

Changed engine version to >=3.0.0
Added CFNetwork.framework to XCode project settings
