### PR TITLE
Android: Add gradle instructions to avoid 'duplicate files' errors

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,5 +72,7 @@
     <source-file src="lib/android/servlet-2-3.jar" target-dir="libs"/>
     <source-file src="lib/android/stateless4j-2.4.0.jar" target-dir="libs"/>
     <source-file src="lib/android/webserver-2-3.jar" target-dir="libs"/>
+
+    <framework src="src/android/cblite.gradle" custom="true" type="gradleReference" />
   </platform>
 </plugin>

--- a/src/android/cblite.gradle
+++ b/src/android/cblite.gradle
@@ -1,0 +1,8 @@
+android {
+	  packagingOptions {
+	    exclude 'META-INF/ASL2.0'
+	    exclude 'META-INF/LICENSE'
+      exclude 'META-INF/NOTICE'
+      exclude 'META-INF/DEPENDENCIES'
+	  }
+}


### PR DESCRIPTION
Im getting the following build error on cordova 4.0, that builds withgradle: 
```
Error: duplicate files during packaging of APK /Users/karl/Development/hat-prototype/build/hat/platforms/android/build/outputs/apk/android-armv7-debug-unaligned.apk
	Path in archive: META-INF/ASL2.0
	Origin 1: /Users/karl/Development/hat-prototype/build/hat/platforms/android/libs/jackson-mapper-asl-1.9.2.jar
	Origin 2: /Users/karl/Development/hat-prototype/build/hat/platforms/android/libs/jackson-core-asl-1.9.2.jar
You can ignore those files in your build.gradle:
	android {
	  packagingOptions {
	    exclude 'META-INF/ASL2.0'
	  }
	}
:packageArmv7Debug FAILED
```
this pr adds a plugin gradle file, that resolves this error