### PR TITLE
Fix issue #71 reported at https://github.com/couchbaselabs/Couchbase-…

### DIFF
--- a/src/ios/CBLite.m
+++ b/src/ios/CBLite.m
@@ -10,37 +10,33 @@
 
 @synthesize liteURL;
 
-- (id) initWithWebView:(UIWebView*)theWebView
+- (void)pluginInitialize
 {
-    self = [super initWithWebView:theWebView];
-    if (self) {
         // todo check domain whitelist to give devs a helpful error message
         [self launchCouchbaseLite];
-    }
-    return self;
 }
 
 - (void)getURL:(CDVInvokedUrlCommand*)urlCommand
 {
-    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[self.liteURL absoluteString]];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:urlCommand.callbackId];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[self.liteURL absoluteString]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:urlCommand.callbackId];
 }
 
 
 - (void)launchCouchbaseLite
 {
-    NSLog(@"Launching Couchbase Lite...");
-    CBLManager* dbmgr = [CBLManager sharedInstance];
-    CBLRegisterJSViewCompiler();
+        NSLog(@"Launching Couchbase Lite...");
+        CBLManager* dbmgr = [CBLManager sharedInstance];
+        CBLRegisterJSViewCompiler();
 #if 1
-    // Couchbase Lite 1.0's CBLRegisterJSViewCompiler function doesn't register the filter compiler
-    if ([CBLDatabase filterCompiler] == nil) {
-        Class cblJSFilterCompiler = NSClassFromString(@"CBLJSFilterCompiler");
-        [CBLDatabase setFilterCompiler: [[cblJSFilterCompiler alloc] init]];
-    }
+        // Couchbase Lite 1.0's CBLRegisterJSViewCompiler function doesn't register the filter compiler
+        if ([CBLDatabase filterCompiler] == nil) {
+                Class cblJSFilterCompiler = NSClassFromString(@"CBLJSFilterCompiler");
+                [CBLDatabase setFilterCompiler: [[cblJSFilterCompiler alloc] init]];
+        }
 #endif
-    self.liteURL = dbmgr.internalURL;
-    NSLog(@"Couchbase Lite url = %@", self.liteURL);
+        self.liteURL = dbmgr.internalURL;
+        NSLog(@"Couchbase Lite url = %@", self.liteURL);
 }
 
 @end


### PR DESCRIPTION
Fix issue https://github.com/couchbaselabs/Couchbase-Lite-PhoneGap-Plugin/issues/71
IOS Code fails to compile using Cordova 6 and IOS 4.

Removed initWithWebView:(UIWebView*)theWebView as it no longer exists in Cordova 6.
Moved launchCouchbaseLite call to pluginInitialize
	modified:   src/ios/CBLite.m

I also tested using Cordova 5.4.1 and ios 3.9.2