### PR TITLE
add package.json file for cordova 7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "Couchbase Lite",
+  "version": "1.4.0",
+  "description": "Install Couchbase Lite in your app to enable JSON sync",
+  "cordova": {
+    "id": "com.couchbase.lite.phonegap",
+    "platforms": [
+      "ios",
+      "android"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/couchbaselabs/Couchbase-Lite-PhoneGap-Plugin.git"
+  },
+  "keywords": [
+    "couchbase",
+    "couchbase-lite-phonegap",
+    "couchbase-lite",
+    "cordova"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Couchbase",
+  "bugs": {
+    "url": "https://forums.couchbase.com/c/mobile/couchbase-lite"
+  },
+  "homepage": "https://github.com/couchbaselabs/Couchbase-Lite-PhoneGap-Plugin"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Couchbase Lite",
+  "name": "com.couchbase.lite.phonegap",
   "version": "1.4.0",
   "description": "Install Couchbase Lite in your app to enable JSON sync",
   "cordova": {


### PR DESCRIPTION
From cordova (https://cordova.apache.org/news/2017/05/04/cordova-7.html):

```Platforms and plugins are now required to have a package.json file```